### PR TITLE
[ci] fix swarm deploy build

### DIFF
--- a/.github/workflows/swarm-upload.yaml
+++ b/.github/workflows/swarm-upload.yaml
@@ -23,7 +23,6 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm run export
       - name: Upload to Swarm
         uses: ethersphere/swarm-actions/upload-dir@v0
         id: upload


### PR DESCRIPTION
 `next export` has been removed in favor of 'output: export' in next.config.js.