### PR TITLE
ci: run swarm-upload on self-hosted runners

### DIFF
--- a/.github/workflows/swarm-upload.yaml
+++ b/.github/workflows/swarm-upload.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, bee]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Switch this workflow to the org's self-hosted runners. Existing triggers unchanged.