### PR TITLE
ci: pass authorization header to upload + write-feed

### DIFF
--- a/.github/workflows/swarm-upload.yaml
+++ b/.github/workflows/swarm-upload.yaml
@@ -33,6 +33,8 @@ jobs:
           bee-url: ${{ secrets.PRIVATE_BEE_URL }}
           timeout: 300000
           deferred: false
+          headers: |
+            authorization: ${{ secrets.PRIVATE_API_TOKEN }}
 
       - name: Setup feed
         uses: ethersphere/swarm-actions/write-feed@latest
@@ -43,6 +45,8 @@ jobs:
           postage-batch-id: ${{ secrets.PRIVATE_POSTAGE_BATCH_ID }}
           bee-url: ${{ secrets.PRIVATE_BEE_URL }}
           signer: ${{ secrets.PRIVATE_SIGNER }}
+          headers: |
+            authorization: ${{ secrets.PRIVATE_API_TOKEN }}
 
       - uses: ethersphere/swarm-actions/reference-to-cid@v0
         id: cid


### PR DESCRIPTION
Upload + Setup feed steps weren't passing the Authorization header, so the gateway returned 401. Adding the headers block fixes this.