### PR TITLE
docs: add maintainer to README (org audit #859)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Development
 
+> **Maintained by:** devrel team
+
+
 First, run the development server:
 
 ```bash


### PR DESCRIPTION
Adds `Maintained by: devrel team` to the README per org audit ethersphere/DevRel#859.