### PR TITLE
fix: default macOS download to arm64 and add Intel Mac fallback link

### DIFF
--- a/components/common/ButtonDownload.tsx
+++ b/components/common/ButtonDownload.tsx
@@ -39,8 +39,10 @@ const DownloadButton: React.FC<ButtonProps> = ({
     return null;
   }
 
+  const classNameBase =
+    "transition duration-200 inline-flex items-center text-sm font-semibold px-4 text-center rounded-full leading-[2.3] group focus:outline-none";
   const className = cx(
-    "transition duration-200 inline-flex items-center text-sm font-semibold px-4 text-center rounded-full leading-[2.3] group focus:outline-none",
+    classNameBase,
     classNameBackground,
     classNameColor
   );
@@ -48,14 +50,26 @@ const DownloadButton: React.FC<ButtonProps> = ({
   const downloadText = "Download for " + assetInfo.osName + " ->";
 
   return (
-    <a
-      href={assetInfo.downloadUrl}
-      target="_blank"
-      rel="noreferrer"
-      className={className}
-    >
-      {downloadText}
-    </a>
+    <>
+      <a
+        href={assetInfo.downloadUrl}
+        target="_blank"
+        rel="noreferrer"
+        className={className}
+      >
+        {downloadText}
+      </a>
+      {assetInfo.alternativeDownloadUrl && (
+        <a
+          href={assetInfo.alternativeDownloadUrl}
+          target="_blank"
+          rel="noreferrer"
+          className={cx(classNameBase, "text-[#F6F7F9] hover:text-opacity-70")}
+        >
+          Download for Intel Mac -&gt;
+        </a>
+      )}
+    </>
   );
 };
 

--- a/hooks/useOsAsset.ts
+++ b/hooks/useOsAsset.ts
@@ -5,6 +5,9 @@ interface AssetInfo {
   osName: string;
   architecture?: string;
   downloadUrl?: string;
+  // Secondary download for platforms where one build can't serve everyone,
+  // e.g. on macOS the main download is arm64 and this holds the x64 build.
+  alternativeDownloadUrl?: string;
   version?: string; // We'll add a version property
   isLoading: boolean;
 }
@@ -30,19 +33,19 @@ const useOsAsset = (repository: string): AssetInfo => {
         const latestVersion = data.tag_name;
 
         const ua = window.navigator.userAgent;
-        const platform = window.navigator.platform;
         let osName = 'Unknown';
         let architecture = 'x64'; // Default to x64
 
         // 1. Detect OS and architecture
         if (ua.includes('Win')) {
           osName = 'Windows';
-          architecture = 'x64'; 
+          architecture = 'x64';
         } else if (ua.includes('Mac')) {
           osName = 'macOS';
-          if (platform.includes('arm64') || ua.includes('arm64')) {
-            architecture = 'arm64';
-          }
+          // Browsers report 'MacIntel' even on Apple Silicon, so the CPU
+          // cannot be detected reliably. The main download is always arm64;
+          // Intel users get a separate x64 link (alternativeDownloadUrl).
+          architecture = 'arm64';
         } else if (ua.includes('Linux')) {
           osName = 'Linux';
           if (ua.includes('arm64') || ua.includes('aarch64')) {
@@ -58,8 +61,13 @@ const useOsAsset = (repository: string): AssetInfo => {
           ? `https://github.com/${repository}/releases/download/${latestVersion}/${assetFileName}`
           : undefined;
 
+        const alternativeDownloadUrl =
+          osName === 'macOS'
+            ? `https://github.com/${repository}/releases/download/${latestVersion}/${getAssetName(osName, 'x64', latestVersion)}`
+            : undefined;
+
         // 4. Update the state with the final asset information.
-        setAsset({ osName, architecture, downloadUrl, version: latestVersion, isLoading: false });
+        setAsset({ osName, architecture, downloadUrl, alternativeDownloadUrl, version: latestVersion, isLoading: false });
 
       } catch (error) {
         console.error('Error fetching release assets:', error);


### PR DESCRIPTION
## Problem

The download button tried to detect Mac CPU architecture from `navigator.platform` / user agent, but browsers report `MacIntel` even on Apple Silicon. As a result, Apple Silicon users were served the x64 build.
See:
- https://github.com/ethersphere/ethswarm-nextjs/issues/291
- https://github.com/ethersphere/swarm-desktop/issues/282
- https://github.com/ethersphere/swarm-desktop/issues/284

  ## Changes

- `hooks/useOsAsset.ts`: stop trying to detect Mac CPU architecture — **always** use the arm64 build as the primary macOS download, and expose a new `alternativeDownloadUrl` pointing to the x64 build
- `components/common/ButtonDownload.tsx`: render a secondary "Download for Intel Mac ->" link next to the main button on macOS