### PR TITLE
ci: disable setup-node package-manager-cache probe

### DIFF
--- a/.github/workflows/swarm-upload.yaml
+++ b/.github/workflows/swarm-upload.yaml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+          # setup-node >=6.5.0 probes `npm --version` to auto-detect the package
+          # manager. That probe hangs on our self-hosted runners. package.json
+          # declares no packageManager/devEngines field, so no caching is lost.
+          package-manager-cache: false
       - name: Build
         env:
           TINA_BRANCH: ${{ secrets.TINA_BRANCH }}


### PR DESCRIPTION
The `Swarm Upload` workflow hangs on the `actions/setup-node` step and never completes.

`actions/setup-node` 6.5.0 enables `package-manager-cache` by default. That makes the action shell out to `npm --version` to auto-detect the package manager, and the probe spins indefinitely on the self-hosted runners (observed burning >12 min of CPU at ~73% without returning). `npm --version` returns normally when invoked directly on the same host, so this is specific to how the action invokes it.

Nothing in this repo changed — the workflow has been untouched since May and last ran green on 2026-07-23. `@v6` is a moving tag, so the runner picked up the new action behaviour on its own.

`package.json` declares neither a top-level `packageManager` field nor `devEngines.packageManager`, so dependency caching was never active for this workflow. Disabling the probe therefore loses nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)